### PR TITLE
TP 6: cache en Redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,13 @@
 			<version>2.10.1</version>
 		</dependency>		
 		<dependency>
+		    <groupId>redis.clients</groupId>
+		    <artifactId>jedis</artifactId>
+		    <version>2.7.2</version>
+		    <type>jar</type>
+		    <scope>compile</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.10</version>

--- a/src/main/java/org/unq/epers/grupo5/rentauto/model/Auto.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/model/Auto.xtend
@@ -3,12 +3,15 @@ package org.unq.epers.grupo5.rentauto.model
 import java.util.Date
 import java.util.List
 import javax.persistence.Entity
+import javax.persistence.EntityListeners
 import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import org.eclipse.xtend.lib.annotations.Accessors
+import org.unq.epers.grupo5.rentauto.persistence.CacheListener
 
 @Entity
 @Accessors
+@EntityListeners(CacheListener)
 class Auto extends Entidad {
 	String marca
 	String modelo

--- a/src/main/java/org/unq/epers/grupo5/rentauto/model/Reserva.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/model/Reserva.xtend
@@ -2,16 +2,19 @@ package org.unq.epers.grupo5.rentauto.model
 
 import java.util.Date
 import javax.persistence.Entity
+import javax.persistence.EntityListeners
 import javax.persistence.ManyToOne
+import javax.persistence.OneToOne
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.joda.time.DateTime
 import org.joda.time.Days
+import org.unq.epers.grupo5.rentauto.persistence.CacheListener
 
 import static ar.edu.unq.epers.extensions.DateExtensions.*
-import javax.persistence.OneToOne
 
 @Entity
 @Accessors
+@EntityListeners(CacheListener)
 class Reserva extends Entidad {
 	Integer numeroSolicitud
 	Date inicio

--- a/src/main/java/org/unq/epers/grupo5/rentauto/persistence/CacheListener.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/persistence/CacheListener.xtend
@@ -2,10 +2,18 @@ package org.unq.epers.grupo5.rentauto.persistence
 
 import javax.persistence.PrePersist
 import org.unq.epers.grupo5.rentauto.model.Auto
+import org.unq.epers.grupo5.rentauto.model.Reserva
 
 class CacheListener {
-    @PrePersist
-    def void clearCache(Auto auto) {
-    	RedisCache.clearFor(auto.ubicacion)
-    }	
+	@PrePersist
+	def void clearCache(Object entity) {
+		RedisCache.clearFor(entity.ubicacion)
+	}
+
+	private def ubicacion(Object entity) {
+		switch (entity) {
+			Auto: entity.ubicacion
+			Reserva: entity.origen
+		}
+	}
 }

--- a/src/main/java/org/unq/epers/grupo5/rentauto/persistence/CacheListener.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/persistence/CacheListener.xtend
@@ -1,0 +1,11 @@
+package org.unq.epers.grupo5.rentauto.persistence
+
+import javax.persistence.PrePersist
+import org.unq.epers.grupo5.rentauto.model.Auto
+
+class CacheListener {
+    @PrePersist
+    def void clearCache(Auto auto) {
+    	RedisCache.clearFor(auto.ubicacion)
+    }	
+}

--- a/src/main/java/org/unq/epers/grupo5/rentauto/persistence/RedisCache.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/persistence/RedisCache.xtend
@@ -38,5 +38,10 @@ class RedisCache {
 	
 	private def toRedisValue(List<Auto> autos) {
 		autos.map [ id.toString ].join(",")
-	}	
+	}
+	
+	def static clearFor(Ubicacion ubicacion) {
+		new RedisCache(null).clear
+	}
+	
 }

--- a/src/main/java/org/unq/epers/grupo5/rentauto/persistence/RedisCache.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/persistence/RedisCache.xtend
@@ -1,0 +1,38 @@
+package org.unq.epers.grupo5.rentauto.persistence
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.List
+import java.util.Optional
+import org.unq.epers.grupo5.rentauto.model.Auto
+import org.unq.epers.grupo5.rentauto.model.Ubicacion
+import redis.clients.jedis.Jedis
+
+class RedisCache {
+	val jedis = new Jedis("localhost")
+	Repository repository
+	
+	new(Repository repository) {
+		this.repository = repository
+	}
+	
+	def Optional<List<Auto>> get(Ubicacion ubicacion, Date dia) {
+		Optional.ofNullable(jedis.get(makeKey(ubicacion, dia))).map[toAutos]
+	}	
+	
+	def save(Ubicacion ubicacion, Date dia, List<Auto> autos) {
+		jedis.set(makeKey(ubicacion, dia), autos.toRedisValue)		
+	}
+	
+	private def String makeKey(Ubicacion ubicacion, Date dia) {
+		'''«ubicacion.id»-«new SimpleDateFormat('yyyy-MM-dd').format(dia)»'''
+	}
+	
+	private def toAutos(String redisValue) {
+		repository.autosById(redisValue.split(",").map[Long.valueOf(it)])
+	}	
+	
+	private def toRedisValue(List<Auto> autos) {
+		autos.map [ id.toString ].join(",")
+	}	
+}

--- a/src/main/java/org/unq/epers/grupo5/rentauto/persistence/RedisCache.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/persistence/RedisCache.xtend
@@ -24,8 +24,12 @@ class RedisCache {
 		jedis.set(makeKey(ubicacion, dia), autos.toRedisValue)		
 	}
 	
+	def clear() {
+		jedis.flushDB
+	}
+	
 	private def String makeKey(Ubicacion ubicacion, Date dia) {
-		'''«ubicacion.id»-«new SimpleDateFormat('yyyy-MM-dd').format(dia)»'''
+		'''«ubicacion.id»/«new SimpleDateFormat('yyyy-MM-dd').format(dia)»'''
 	}
 	
 	private def toAutos(String redisValue) {

--- a/src/main/java/org/unq/epers/grupo5/rentauto/persistence/Repository.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/persistence/Repository.xtend
@@ -38,6 +38,10 @@ class Repository implements WithGlobalEntityManager, EntityManagerOps {
 		.resultList
 	}
 	
+	def clearCache() {
+		cache.clear
+	}
+	
 	private def createQuery(String origen, String destino, String inicio, String fin, List<String> extraConditions) {
 		createQuery('''
 		select a

--- a/src/main/java/org/unq/epers/grupo5/rentauto/persistence/Repository.xtend
+++ b/src/main/java/org/unq/epers/grupo5/rentauto/persistence/Repository.xtend
@@ -20,11 +20,10 @@ class ReservaExample {
 }
 
 class Repository implements WithGlobalEntityManager, EntityManagerOps {
+	val cache = new RedisCache(this)
+	
 	def autosDisponibles(Ubicacion ubicacion, Date dia) {
-		createQuery("ubicacion", "ubicacion", "dia", "dia", #[])
-		.setParameter("ubicacion", ubicacion)
-		.setParameter("dia", dia)
-		.resultList
+		cache.get(ubicacion, dia).orElseGet [ getFromSQL(ubicacion, dia) ]
 	}
 	
 	def autosReservables(ReservaExample example) {
@@ -33,7 +32,13 @@ class Repository implements WithGlobalEntityManager, EntityManagerOps {
 		.resultList
 	}
 	
-	def createQuery(String origen, String destino, String inicio, String fin, List<String> extraConditions) {
+	def autosById(Iterable<Long> ids) {
+		createQuery("select a from Auto as a where a.id in (:ids)", Auto)
+		.setParameter("ids", ids)
+		.resultList
+	}
+	
+	private def createQuery(String origen, String destino, String inicio, String fin, List<String> extraConditions) {
 		createQuery('''
 		select a
 		from Auto as a
@@ -54,6 +59,17 @@ class Repository implements WithGlobalEntityManager, EntityManagerOps {
 			exists (from Reserva as r2 where r2.auto = a and r != r2 and r2.inicio > :«fin»)
 		)
 		''', Auto)
+	}
+	
+	private def getFromSQL(Ubicacion ubicacion, Date dia) {
+		val results = createQuery("ubicacion", "ubicacion", "dia", "dia", #[])
+		.setParameter("ubicacion", ubicacion)
+		.setParameter("dia", dia)
+		.resultList
+		
+		cache.save(ubicacion, dia, results)
+		
+		results
 	}
 	
 	static def <T extends Query> setParametersFromExample(T query, Object example) {

--- a/src/test/java/org/unq/epers/grupo5/rentauto/persistence/RepositoryTest.xtend
+++ b/src/test/java/org/unq/epers/grupo5/rentauto/persistence/RepositoryTest.xtend
@@ -151,4 +151,10 @@ class RepositoryTest extends BasePersistenceTest {
 		
 		#[hilux].assertEquals(repository.autosReservables(reservaExample))
 	}
+	
+	@Test
+	def void losAutosDisponiblesSeCachean() {
+		#[gol, hilux].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
+		#[gol, hilux].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
+	}
 }

--- a/src/test/java/org/unq/epers/grupo5/rentauto/persistence/RepositoryTest.xtend
+++ b/src/test/java/org/unq/epers/grupo5/rentauto/persistence/RepositoryTest.xtend
@@ -85,6 +85,7 @@ class RepositoryTest extends BasePersistenceTest {
 	@After
 	def void tearDown() {
 		rollbackTransaction()
+		repository.clearCache
 	}
 	
 	@Test

--- a/src/test/java/org/unq/epers/grupo5/rentauto/persistence/RepositoryTest.xtend
+++ b/src/test/java/org/unq/epers/grupo5/rentauto/persistence/RepositoryTest.xtend
@@ -158,4 +158,14 @@ class RepositoryTest extends BasePersistenceTest {
 		#[gol, hilux].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
 		#[gol, hilux].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
 	}
+	
+	@Test
+	def void laCacheSeLimpiaAlGuardarUnAutoNuevo() {
+		#[gol, hilux].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
+		
+		val scenic = new Auto("Renault", "Scenic", 2007, "FTS381", new Familiar, 105000d, marDelPlata)
+		persist(scenic)
+		
+		#[gol, hilux, scenic].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
+	}	
 }

--- a/src/test/java/org/unq/epers/grupo5/rentauto/persistence/RepositoryTest.xtend
+++ b/src/test/java/org/unq/epers/grupo5/rentauto/persistence/RepositoryTest.xtend
@@ -168,4 +168,35 @@ class RepositoryTest extends BasePersistenceTest {
 		
 		#[gol, hilux, scenic].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
 	}	
+	
+	@Test
+	def void laCacheSeLimpiaAlGuardarUnaReservaNueva() {
+		#[gol, hilux].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
+		
+		val sanMartin = new Ubicacion("San Martin")
+		persist(sanMartin)
+		
+		val reservaGol = new Reserva => [
+			numeroSolicitud = 999
+			auto = gol
+			origen = marDelPlata
+			destino = sanMartin
+			inicio = nuevaFecha(2015, 11, 1)
+			fin = nuevaFecha(2015, 11, 25)
+			usuario = new Usuario => [
+				nombre = "Miguel"
+				apellido = "Del Sel"
+				username = "miguelds"
+				password = "dameLaPresidencia"
+				email = "miguelds@pro.gov.ar"
+				nacimiento = nuevaFecha(1957, 7, 3)
+				codigo_validacion = "1234567890"				
+			]
+		]
+		
+		gol.agregarReserva(reservaGol)
+		persist(reservaGol)		
+		
+		#[hilux].assertEquals(repository.autosDisponibles(marDelPlata, nuevaFecha(2015, 11, 1)))
+	}	
 }


### PR DESCRIPTION
- Los datos se cachean luego de la primera consulta a ese par (ubicacion, fecha)
- Se crea una entrada por (ubicacion, fecha), conteniendo unicamente los ids de los autos separados por coma. Esto lo hice así para no correr el riesgo de que los datos de los autos queden obsoletos.
- Al crear un nuevo `Auto` o `Reserva` se limpia la caché. TODO: hacer la limpieza más inteligente, ahora simplemente borra todo.
- Para esto último utilicé los `EntityListeners` que [provee JPA](https://docs.jboss.org/hibernate/entitymanager/3.5/reference/en/html/listeners.html).
